### PR TITLE
Etkinlik tarihini güncelleme konusunda bazı kısıtlamalar eklendi.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,4 @@ target/
 log/
 upload/
 .git
-application-dev.properties
-application-prod.properties
-application-test.properties
+application-*.properties

--- a/src/main/java/javaday/istanbul/sliconf/micro/controller/event/CreateEventRoute.java
+++ b/src/main/java/javaday/istanbul/sliconf/micro/controller/event/CreateEventRoute.java
@@ -20,6 +20,7 @@ import spark.Route;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -181,6 +182,14 @@ public class CreateEventRoute implements Route {
         if (Objects.nonNull(dbEvent.getExecutiveUser()) && !dbEvent.getExecutiveUser().equals(userId)) {
             return new ResponseMessage(false, messageProvider.getMessage("onlyOwnedEventsCanBeUpdated"), event);
         }
+
+        if (LocalDateTime.now().plusHours(48).isAfter(event.getStartDate()))
+            event.setDateLock(true);
+        if((event.getStartDate() != dbEvent.getStartDate()) && event.isDateLock())
+            return new ResponseMessage(false, messageProvider.getMessage("eventStartDateCanNotBeUpdatedAnymore"), event);
+        if(event.getStartDate().minusWeeks(1).isBefore(LocalDateTime.now()))
+            return new ResponseMessage(false, messageProvider.getMessage("eventStartDateCanNotBeUpdatedGivenDate"), event);
+
 
         copyUpdatedFields(dbEvent, event);
 

--- a/src/main/java/javaday/istanbul/sliconf/micro/model/event/Event.java
+++ b/src/main/java/javaday/istanbul/sliconf/micro/model/event/Event.java
@@ -29,6 +29,7 @@ public class Event {
     private String logoPath;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
+    private boolean dateLock;
     private String executiveUser;
     private List<AgendaElement> agenda;
     private List<Speaker> speakers;
@@ -43,4 +44,5 @@ public class Event {
     private StatusDetails statusDetails;
     private TotalUsers totalUsers;
     private BaseEventState eventState;
+
 }

--- a/src/main/resources/eventController.properties
+++ b/src/main/resources/eventController.properties
@@ -14,3 +14,5 @@ onlyOwnedEventsCanBeUpdated=Only owned events can be updated!
 eventNameAlreadyRegistered=Event name already registered!
 eventSuccessfullyUpdated=Event successfully updated!
 eventStatisticsQueried=Event statistics queried!
+eventStartDateCanNotBeUpdatedAnymore=The event date cannot be changed when less than 48 hours remain to the beginning of the event!
+eventStartDateCanNotBeUpdatedGivenDate=The event start date can only be changed to a date after a week!


### PR DESCRIPTION
Etkinlik tarihi etkinliğe 48 saatten az kaldı ise değiştirilemiyor. Aynı zamanda değiştirilebildiği zaman da en erken 1 hafta sonrasına değiştirilebiliyor.